### PR TITLE
Add GitHub Pages link directly in README (closes #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Pick the book that matches your background. Books are grouped by complexity so y
 
 Each book has 15–16 chapters with Mermaid diagrams, editable Rust playgrounds, exercises, and full-text search.
 
-> **Tip:** You can read the markdown source directly on GitHub, or browse the rendered site with sidebar navigation and search at the GitHub Pages site (link in the repo's About section).
+> **Tip:** You can read the markdown source directly on GitHub, or browse the rendered site with sidebar navigation and search at the [GitHub Pages site](https://microsoft.github.io/RustTraining/).
 >
 > **Local serving:** For the best reading experience (keyboard navigation between chapters, instant search, offline access), clone the repo and run:
 > ```


### PR DESCRIPTION
The GitHub Pages URL was only referenced indirectly via the repo's About section, which is hard to find on mobile. Added a direct clickable link.

