### PR TITLE
Recommend gimli addr2line along with cargo-flamegraph

### DIFF
--- a/engineering-book/src/ch03-benchmarking-measuring-what-matters.md
+++ b/engineering-book/src/ch03-benchmarking-measuring-what-matters.md
@@ -262,7 +262,7 @@ cargo build --release
 # debug = true          # Add this temporarily for profiling
 
 # Step 2: Record with perf
-perf record -g --call-graph=dwarf ./target/release/diag_tool --run-diagnostics
+perf record --call-graph=dwarf ./target/release/diag_tool --run-diagnostics
 
 # Step 3: Generate a flamegraph
 # Install: cargo install flamegraph


### PR DESCRIPTION
The system `addr2line` tool used by `perf script` and `cargo flamegraph` is desperately slow. Please use gimli's `addr2line`.

This is also recommended by https://github.com/flamegraph-rs/flamegraph#use-custom-addr2line-binary-for-perf (also edited by me LOL).

I personally use [Firefox Profiler](https://profiler.firefox.com/) to view perf files BTW.

For the second commit, `--call-graph` implies `-g` on `perf record`.