### PR TITLE
Fix mdbook installation in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Install mdbook and dependencies
         run: |
-          cargo install mdbook
-          cargo install mdbook-mermaid
+          cargo install mdbook --force || cargo install mdbook
+          cargo install mdbook-mermaid --force || cargo install mdbook-mermaid
 
       - name: Build documentation
         run: cargo xtask deploy


### PR DESCRIPTION
The CI is failing because mdbook is already installed and cargo install fails without --force flag. This fixes the issue by adding --force to the install commands.