### PR TITLE
Use `size_of` from prelude

### DIFF
--- a/rust-patterns-book/src/ch02-traits-in-depth.md
+++ b/rust-patterns-book/src/ch02-traits-in-depth.md
@@ -394,9 +394,9 @@ fn main() {
     }
 
     // Size comparison:
-    println!("size_of::<&Circle>()        = {}", std::mem::size_of::<&Circle>());
+    println!("size_of::<&Circle>()        = {}", size_of::<&Circle>());
     // → 8 bytes (one pointer — the compiler knows the type)
-    println!("size_of::<&dyn Drawable>()  = {}", std::mem::size_of::<&dyn Drawable>());
+    println!("size_of::<&dyn Drawable>()  = {}", size_of::<&dyn Drawable>());
     // → 16 bytes (data_ptr + vtable_ptr)
 }
 ```

--- a/rust-patterns-book/src/ch11-serialization-zero-copy-and-binary-data.md
+++ b/rust-patterns-book/src/ch11-serialization-zero-copy-and-binary-data.md
@@ -323,7 +323,7 @@ struct IpmiHeader {
 // --- Safe binary parsing with manual deserialization ---
 impl IpmiHeader {
     fn from_bytes(data: &[u8]) -> Option<Self> {
-        if data.len() < std::mem::size_of::<Self>() {
+        if data.len() < size_of::<Self>() {
             return None;
         }
         Some(IpmiHeader {


### PR DESCRIPTION
[Rust 1.80](https://github.com/rust-lang/rust/releases/tag/1.80.0) added `size_of`, `size_of_val`, `align_of`, and `align_of_val` to the prelude.

PR replaces `std::mem::size_of` with `size_of` for conciseness.