### PR TITLE
fixed the fat pointer layout diagram in ch02 of rust-patterns-book

### DIFF
--- a/rust-patterns-book/src/ch02-traits-in-depth.md
+++ b/rust-patterns-book/src/ch02-traits-in-depth.md
@@ -335,13 +335,13 @@ A `&dyn Trait` (or `Box<dyn Trait>`) is a **fat pointer** — two machine words:
 │  ↓           │  ↓                                │
 │  ┌─────────┐ │  ┌──────────────────────────────┐ │
 │  │ Circle  │ │  │ vtable for <Circle as        │ │
-│  │ {       │ │  │           Drawable>           │ │
+│  │ {       │ │  │           Drawable>          │ │
 │  │  r: 5.0 │ │  │                              │ │
 │  │ }       │ │  │  drop_in_place: 0x7f...a0    │ │
-│  └─────────┘ │  │  size:           8            │ │
-│              │  │  align:          8            │ │
-│              │  │  draw:          0x7f...b4     │ │
-│              │  │  bounding_box:  0x7f...c8     │ │
+│  └─────────┘ │  │  size:           8           │ │
+│              │  │  align:          8           │ │
+│              │  │  draw:          0x7f...b4    │ │
+│              │  │  bounding_box:  0x7f...c8    │ │
 │              │  └──────────────────────────────┘ │
 └──────────────┴───────────────────────────────────┘
 ```


### PR DESCRIPTION
<img width="1039" height="455" alt="Screenshot 2026-03-26 at 7 14 57 PM" src="https://github.com/user-attachments/assets/a383936c-156a-47a7-a25b-303274698e6c" />
<img width="674" height="455" alt="Screenshot 2026-03-26 at 7 17 38 PM" src="https://github.com/user-attachments/assets/7e934256-0c43-4219-b2e9-a35dde973957" />
