### PR TITLE
Fix typo in the comment of the first code example in ch05-data-struct…

### DIFF
--- a/c-cpp-book/src/ch05-data-structures.md
+++ b/c-cpp-book/src/ch05-data-structures.md
@@ -81,7 +81,7 @@ fn main() {
 
 ----
 # Rust slices
-- Rust references can be used create subsets of arrays
+- Rust references can be used to create subsets of arrays
     - Unlike arrays, which have a static fixed length determined at compile time, slices can be of arbitrary size. Internally, slices are implemented as a "fat-pointer" that contains the length of the slice and a pointer to the starting element in the original array
 ```rust
 fn main() {


### PR DESCRIPTION
This PR fixes a typo in a comment line of code snippet appeared on ch5 of the c-cpp book.

```
        // Initializes an array of 10 elements and sets all to 42
        let a : [u8; 3] = [42; 3];
```

It should be 3 elements.  Not 10.