### PR TITLE
Fix incorrect claim that Python coroutines execute eagerly (closes #44)

### DIFF
--- a/async-book/src/ch01-why-async-is-different-in-rust.md
+++ b/async-book/src/ch01-why-async-is-different-in-rust.md
@@ -71,14 +71,13 @@ var result = await task; // Just waits for completion
 
 This is the single most important mental shift:
 
-| | C# / JavaScript / Python | Go | Rust |
-|---|---|---|---|
-| **Creation** | `Task` starts executing immediately | Goroutine starts immediately | `Future` does nothing until polled |
-| **Dropping** | Detached task continues running | Goroutine runs until return | Dropping a Future cancels it |
-| **Runtime** | Built into the language/VM | Built into the binary (M:N scheduler) | You choose (tokio, smol, etc.) |
-| **Scheduling** | Automatic (thread pool) | Automatic (GMP scheduler) | Explicit (`spawn`, `block_on`) |
-| **Cancellation** | `CancellationToken` (cooperative) | `context.Context` (cooperative) | Drop the future (immediate) |
-
+| | C# / JavaScript | Go | Python | Rust |
+| --- | --- | --- | --- | --- |
+| **Creation** | `Task`/`Promise` starts executing immediately | Goroutine starts immediately | Calling `async def` returns an inert coroutine — no code runs until awaited | `Future` does nothing until polled |
+| **Dropping** | Detached task continues running | Goroutine runs until return | Unawaited coroutine is GC'd (with a warning) | Dropping a Future cancels it |
+| **Runtime** | Built into the language/VM | Built into the binary (M:N scheduler) | `asyncio` event loop (must be started) | You choose (tokio, smol, etc.) |
+| **Scheduling** | Automatic (thread pool) | Automatic (GMP scheduler) | Explicit (`await`, `create_task`) | Explicit (`spawn`, `block_on`) |
+| **Cancellation** | `CancellationToken` (cooperative) | `context.Context` (cooperative) | `Task.cancel()` (cooperative) | Drop the future (immediate) |
 ```rust
 // To actually RUN a future, you need an executor:
 #[tokio::main]


### PR DESCRIPTION
Fixes the "Lazy Futures vs Eager Tasks" comparison table in async-book/src/ch01-why-async-is-different-in-rust.md which incorrectly grouped Python with C#/JavaScript as having eager async execution.
Python's async def functions return inert coroutine objects — no code runs until the coroutine is explicitly awaited or scheduled. Separated Python into its own column to reflect this.
Closes #44