### PR TITLE
Pin mdbook and mdbook-mermaid to compatible versions (closes #39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Each book has 15–16 chapters with Mermaid diagrams, editable Rust playgrounds,
 > # Install Rust via rustup if you don't have it yet:
 > # https://rustup.rs/
 >
-> cargo install mdbook mdbook-mermaid
+> cargo install mdbook@0.4.52 mdbook-mermaid@0.14.0
 > cargo xtask serve          # builds all books and opens a local server
 > ```
 
@@ -78,7 +78,7 @@ Each book has 15–16 chapters with Mermaid diagrams, editable Rust playgrounds,
 Install [Rust via **rustup**](https://rustup.rs/) if you haven't already, then:
 
 ```bash
-cargo install mdbook mdbook-mermaid
+cargo install mdbook@0.4.52 mdbook-mermaid@0.14.0
 ```
 
 ### Build & serve


### PR DESCRIPTION
mdbook 0.5.x changed the preprocessor JSON format, breaking mdbook-mermaid 0.17.0 with 'Unable to parse the input' errors. Pin to mdbook 0.4.52 + mdbook-mermaid 0.14.0 which are known to work together.