### PR TITLE
fix: update outdated borrow checker example in chapter 5 of "Rust for C/C++ Programmers" to reflect NLL behavior (fixes #55)

### DIFF
--- a/c-cpp-book/src/ch05-data-structures.md
+++ b/c-cpp-book/src/ch05-data-structures.md
@@ -71,8 +71,18 @@ fn main() {
         let b = &a;
         let c = b;
         println!("{} {}", *b, *c); // The compiler automatically dereferences *c
-        // Illegal because b and still are still in scope
-        // let d = &mut a;
+        
+        let d = &mut a;
+        
+        /* 
+         * Uncommenting the line below would be cause the 
+         * program to not compile, because `b` is used 
+         * while the mutable reference `d` is live in the current scope
+         * 
+         * You cannot have a mutable and immutable reference in use in the same scope
+         * at the same time!
+         */
+        // println!("{}", *b);
     }
     let d = &mut a; // Ok: b and c are not in scope
     *d = 43;


### PR DESCRIPTION
Fixes #55 

The original example relied on lexical scope to demonstrate that a mutable and immutable reference cannot overlap, which no longer triggers a compile error since the introduction of non-lexical lifetimes (NLL) in Rust 1.31 (2018 edition) and 1.36 (2015 edition).

The updated example shows that the borrow checker is not restricting by scope, but rather when using an immutable reference while a mutable one is live in the same scope. You can only have multiple immutable references or one mutable reference in a scope