### PR TITLE
fix: fix license name error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div style="background-color: #d9d9d9; padding: 16px; border-radius: 6px; color: #000000;">
 
-**License** This project is dual-licensed under the [MIT License](LICENSE) and [Creative Commons Attribution 4.0 International (CC-BY-4.0)](LICENSE-DOCS).
+**License** This project is dual-licensed under the [MIT License](LICENSE) and [Creative Commons Attribution-ShareAlike 4.0 International (CC-BY-SA-4.0)](LICENSE-DOCS).
 
 </div>
 


### PR DESCRIPTION
The LICENSE-DOC file indicates the CC-BY-SA-4.0 open-source license; however, the README.md file actually specifies CC-BY-4.0.