### PR TITLE
Fix Mermaid diagram rendering in ch07-1

### DIFF
--- a/c-cpp-book/src/ch07-1-lifetimes-and-borrowing-deep-dive.md
+++ b/c-cpp-book/src/ch07-1-lifetimes-and-borrowing-deep-dive.md
@@ -181,15 +181,15 @@ lifetimes are determined after applying the rules, no annotations are needed.
 
 ```mermaid
 flowchart TD
-    A["Function signature with references"] --> R1
-    R1["Rule 1: Each input reference<br/>gets its own lifetime<br/><br/>fn f(&str, &str)<br/>→ fn f<'a,'b>(&'a str, &'b str)"]
+    A["Function signature<br/>with references"] --> R1
+    R1["Rule 1: Each input<br/>reference gets its own<br/>lifetime<br/><br/>fn f(&amp;str, &amp;str)<br/>→ fn f&lt;'a,'b&gt;(&amp;'a str,<br/>&amp;'b str)"]
     R1 --> R2
-    R2["Rule 2: If exactly ONE input<br/>lifetime, assign it to ALL outputs<br/><br/>fn f(&str) → &str<br/>→ fn f<'a>(&'a str) → &'a str"]
+    R2["Rule 2: If exactly ONE<br/>input lifetime, assign it<br/>to ALL outputs<br/><br/>fn f(&amp;str) → &amp;str<br/>→ fn f&lt;'a&gt;(&amp;'a str)<br/>→ &amp;'a str"]
     R2 --> R3
-    R3["Rule 3: If one input is &self<br/>or &mut self, assign its lifetime<br/>to ALL outputs<br/><br/>fn f(&self, &str) → &str<br/>→ fn f<'a>(&'a self, &str) → &'a str"]
-    R3 --> CHECK{{"All output lifetimes<br/>determined?"}}
-    CHECK -->|"Yes"| OK["✅ No annotations needed"]
-    CHECK -->|"No"| ERR["❌ Compile error:<br/>must annotate manually"]
+    R3["Rule 3: If one input is<br/>&amp;self or &amp;mut self,<br/>assign its lifetime to<br/>ALL outputs<br/><br/>fn f(&amp;self, &amp;str) → &amp;str<br/>→ fn f&lt;'a&gt;(&amp;'a self, &amp;str)<br/>→ &amp;'a str"]
+    R3 --> CHECK{{"All output<br/>lifetimes<br/>determined?"}}
+    CHECK -->|Yes| OK["✅ No annotations<br/>needed"]
+    CHECK -->|No| ERR["❌ Compile error:<br/>must annotate<br/>manually"]
     
     style OK fill:#91e5a3,color:#000
     style ERR fill:#ff6b6b,color:#000


### PR DESCRIPTION
**Problem:**
- Mermaid flowchart nodes had text truncation issues
- Some code examples were not fully visible

**Solution:**
- Added line breaks (<br/>) to distribute content across multiple lines
- Reduced node width by reformatting long lines

**Changes:**
- Lines 182-196 in c-cpp-book/src/ch07-1-lifetimes-and-borrowing-deep-dive.md

Before:
<img width="663" height="558" alt="image" src="https://github.com/user-attachments/assets/46e2ceb1-3dc9-4d96-8901-d13a39f92673" />

After:
<img width="525" height="653" alt="image" src="https://github.com/user-attachments/assets/7154e258-a650-4d7d-a636-2fb594789076" />
