### PR TITLE
Correct markdown formatting for Tokio Quick Start

### DIFF
--- a/rust-patterns-book/src/ch16-asyncawait-essentials.md
+++ b/rust-patterns-book/src/ch16-asyncawait-essentials.md
@@ -37,11 +37,10 @@ async fn fetch_data(url: &str) -> Result<Vec<u8>, reqwest::Error> {
 ### Tokio Quick Start
 
 ```toml
-```
-
 # Cargo.toml
 [dependencies]
 tokio = { version = "1", features = ["full"] }
+```
 
 ```rust,ignore
 use tokio::time::{sleep, Duration};


### PR DESCRIPTION
Fix formatting of the Tokio Quick Start section in the async/await essentials chapter.