### PR TITLE
fix(rust-patterns-book): correct markdown code fence formatting

### DIFF
--- a/rust-patterns-book/src/ch13-macros-code-that-writes-code.md
+++ b/rust-patterns-book/src/ch13-macros-code-that-writes-code.md
@@ -271,8 +271,6 @@ Derive macros live in a separate crate (`proc-macro = true`) and transform
 a token stream using `syn` (parse Rust) and `quote` (generate Rust):
 
 ```toml
-```
-
 # my_derive/Cargo.toml
 [lib]
 proc-macro = true
@@ -281,6 +279,7 @@ proc-macro = true
 syn = { version = "2", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
+```
 
 ```rust
 // my_derive/src/lib.rs

--- a/rust-patterns-book/src/ch15-crate-architecture-and-api-design.md
+++ b/rust-patterns-book/src/ch15-crate-architecture-and-api-design.md
@@ -560,8 +560,6 @@ system guarantees they're valid.
 ### Feature Flags and Conditional Compilation
 
 ```toml
-```
-
 # Cargo.toml
 [features]
 default = ["json"]          # Enabled by default
@@ -573,6 +571,7 @@ full = ["json", "xml"]      # Meta-feature: enables all
 serde = "1"
 serde_json = { version = "1", optional = true }
 quick-xml = { version = "0.31", optional = true }
+```
 
 ```rust
 // Conditional compilation based on features:
@@ -601,8 +600,6 @@ compile_error!("At least one format feature (json, xml) must be enabled");
 For large projects, use a Cargo workspace to share dependencies and build artifacts:
 
 ```toml
-```
-
 # Root Cargo.toml
 [workspace]
 members = [
@@ -622,11 +619,9 @@ tracing = "0.1"
 # In each member's Cargo.toml:
 # [dependencies]
 # serde = { workspace = true }
-
-```rust
+```
 
 **Benefits**:
-```
 
 - Single `Cargo.lock` — all crates use the same dependency versions
 - `cargo test --workspace` runs all tests
@@ -639,8 +634,6 @@ The `.cargo/config.toml` file (at the workspace root or in `$HOME/.cargo/`)
 customizes Cargo behavior without modifying `Cargo.toml`:
 
 ```toml
-```
-
 # .cargo/config.toml
 
 # Default target for this workspace
@@ -665,12 +658,9 @@ IPMI_LIB_PATH = "/usr/lib/bmc"
 # Use a custom registry (for internal packages)
 # [registries.internal]
 # index = "https://gitlab.internal/crates/index"
-
-```rust
+```
 
 Common configuration patterns:
-
-```
 
 | Setting | Purpose | Example |
 |---------|---------|---------|
@@ -763,8 +753,6 @@ extern "C" fn platform_ioctl(fd: i32, request: u64) -> i32;
 ### `cargo deny` and `cargo audit`: Supply-Chain Security
 
 ```bash
-```
-
 # Install security audit tools
 cargo install cargo-deny
 cargo install cargo-audit
@@ -774,16 +762,11 @@ cargo audit
 
 # Comprehensive checks: licenses, bans, advisories, sources
 cargo deny check
-
-```rust
+```
 
 Configure `cargo deny` with a `deny.toml` at the workspace root:
 
-```
-
 ```toml
-```
-
 # deny.toml
 [advisories]
 vulnerability = "deny"      # Fail on known vulnerabilities
@@ -796,8 +779,6 @@ deny = ["GPL-3.0"]          # Reject copyleft licenses
 [bans]
 multiple-versions = "warn"  # Warn if multiple versions of same crate
 deny = [
-
-```rust
     { name = "openssl" },   # Force use of rustls instead
 ]
 

--- a/rust-patterns-book/src/ch16-asyncawait-essentials.md
+++ b/rust-patterns-book/src/ch16-asyncawait-essentials.md
@@ -37,11 +37,10 @@ async fn fetch_data(url: &str) -> Result<Vec<u8>, reqwest::Error> {
 ### Tokio Quick Start
 
 ```toml
-```
-
 # Cargo.toml
 [dependencies]
 tokio = { version = "1", features = ["full"] }
+```
 
 ```rust,ignore
 use tokio::time::{sleep, Duration};


### PR DESCRIPTION
Fix misplaced markdown code fence closing markers across three chapters in the rust-patterns book.

## Changes

This PR corrects formatting issues in:
- **Chapter 13** (Macros): Fixed code fence in derive macro example (Cargo.toml block)
- **Chapter 15** (Crate Architecture): Fixed code fences in feature flags, workspace config, and cargo deny sections
- **Chapter 16** (Async/Await): Fixed code fence in Tokio quick start (Cargo.toml block)

## Impact

These changes ensure proper markdown rendering with correct syntax highlighting for code blocks in the generated documentation.
