### PR TITLE
fix(c-cpp-book): correct typo in type conversion example

### DIFF
--- a/c-cpp-book/src/ch11-from-and-into-traits.md
+++ b/c-cpp-book/src/ch11-from-and-into-traits.md
@@ -106,7 +106,7 @@ fn main() {
     // let g : u32 = f;    // Will not compile
     let g = f as u32;      // Ok, but not preferred. Subject to rules around narrowing
     let g : u32 = f.into(); // Most preferred form; infallible and checked by the compiler
-    //let k : u8 = f.into();  // Fails to compile; narrowing can result in loss of data
+    // let k : u8 = g.into();  // Fails to compile; narrowing can result in loss of data
     
     // Attempting a narrowing operation requires use of try_into
     if let Ok(k) = TryInto::<u8>::try_into(g) {


### PR DESCRIPTION
The commented-out line attempting to narrow u32 to u8 was incorrectly using `f.into()` instead of `g.into()`. Since `f` is already u8, that conversion would trivially succeed. The example should demonstrate narrowing `g` (u32) back to u8, which requires `try_into()` as shown at the end of the block.