### PR TITLE
Rust Patterns, ch01: ensure doctests are verifiable

### DIFF
--- a/rust-patterns-book/src/ch01-generics-the-full-picture.md
+++ b/rust-patterns-book/src/ch01-generics-the-full-picture.md
@@ -351,6 +351,10 @@ impl<K: Eq + Hash + Clone, V> Cache<K, V> {
     }
 
     fn insert(&mut self, key: K, value: V) {
+        if self.capacity == 0 {
+            // no capacity!
+            return;
+        }
         if self.map.contains_key(&key) {
             self.map.insert(key, value);
             return;
@@ -374,6 +378,7 @@ impl<K: Eq + Hash + Clone, V> Cache<K, V> {
 }
 
 fn main() {
+    // Test of a basic cache
     let mut cache = Cache::new(3);
     cache.insert("a", 1);
     cache.insert("b", 2);
@@ -383,6 +388,14 @@ fn main() {
     cache.insert("d", 4); // Evicts "a"
     assert_eq!(cache.get(&"a"), None);
     assert_eq!(cache.get(&"d"), Some(&4));
+
+    // Left to the reader: what type should `capacity` attribute be,
+    // to ensure that such a useless cache cannot be defined?
+    let mut empty_cache = Cache::new(0);
+    empty_cache.insert("0", 0);
+    assert_eq!(empty_cache.get(&"0"), None);
+    assert_eq!(empty_cache.len(), 0);
+
     println!("Cache works! len = {}", cache.len());
 }
 ```


### PR DESCRIPTION
Rust knows how to run code samples written in text documents, and can therefore _prove_ that such samples are correct, with `rustdoc --test src/ch01-traits-in-depth.md`.

This pull request proposes:

- addition of relevant attributes (`ignore` when a sample is only about Rust syntax, `compile_fail` if sample is expected to fail at compilation)
- addition of a corner case in the chapter 01 exercise, and a hint to a Better Way (tm) to handle such a possible but usage-irrelevant case.