### PR TITLE
fix(rust-patterns-book): typo in ch10 in "See also" section

### DIFF
--- a/rust-patterns-book/src/ch10-error-handling-patterns.md
+++ b/rust-patterns-book/src/ch10-error-handling-patterns.md
@@ -188,7 +188,7 @@ match result {
 > - `#[from]` auto-generates `From` impls; `.context()` adds human-readable wrappers
 > - `?` desugars to `From::from()` + early return; works in `main()` returning `Result`
 
-> **See also:** [Ch 14 — API Design](ch15-crate-architecture-and-api-design.md) for "parse, don't validate" patterns. [Ch 10 — Serialization](ch11-serialization-zero-copy-and-binary-data.md) for serde error handling.
+> **See also:** [Ch 14 — API Design](ch15-crate-architecture-and-api-design.md) for "parse, don't validate" patterns. [Ch 11 — Serialization](ch11-serialization-zero-copy-and-binary-data.md) for serde error handling.
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
<img width="977" height="370" alt="Screenshot 2026-04-04 at 12 32 17 PM" src="https://github.com/user-attachments/assets/22a21d1f-ce12-42ec-8e26-03c8d27fe066" />

-------Corrected-----------
<img width="1057" height="63" alt="Screenshot 2026-04-04 at 12 39 28 PM" src="https://github.com/user-attachments/assets/c5232084-c7aa-4b34-aaca-c9c938d5d1af" />
