### PR TITLE
Fix log_call! macro example in "Rust for Python Programmers" (ch12 closures and iterators)

### DIFF
--- a/python-book/src/ch12-closures-and-iterators.md
+++ b/python-book/src/ch12-closures-and-iterators.md
@@ -306,8 +306,10 @@ struct Point {
 // Declarative macro (like a template)
 macro_rules! log_call {
     ($func_name:expr, $body:expr) => {
-        println!("Calling {}", $func_name);
-        $body
+        {
+            println!("Calling {}", $func_name);
+            $body
+        }
     };
 }
 


### PR DESCRIPTION
Fixes an issue in the log_call! macro where it expands to multiple statements instead of a single expression, causing a type mismatch in usage.

### Problem

The macro was defined as:

```
macro_rules! log_call {
    ($func_name:expr, $body:expr) => {
        println!("Calling {}", $func_name);
        $body
    };
}
```

When used in expression position:

```
fn process(data: &str) -> String {
    log_call!("process", data.to_uppercase())
}

```
it expands to:

```
println!(...);
data.to_uppercase()

```
This results in a compilation error:

`expected `String`, found `()`
`
because the macro does not expand to a single expression.

### Fix

Wrap the macro body in a block expression:

```
macro_rules! log_call {
    ($func_name:expr, $body:expr) => {{
        println!("Calling {}", $func_name);
        $body
    }};
}
```

This ensures the macro expands to a single expression whose value is the result of $body.

Result

- Fixes compilation error in the example
- Demonstrates correct macro usage in expression position
- Improves clarity for learners