### PR TITLE
Fix race condition in "The Waker Contract" example (Fixes #85)

### DIFF
--- a/async-book/src/ch02-the-future-trait.md
+++ b/async-book/src/ch02-the-future-trait.md
@@ -108,12 +108,12 @@ impl Future for Delay {
     type Output = ();
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-        // Check if already completed
+        // Check if already completed before storing waker
         if *self.completed.lock().unwrap() {
             return Poll::Ready(());
         }
 
-        // Store the waker so the background thread can wake us
+        // Store the waker - executor may pass a new one on each poll
         *self.waker_stored.lock().unwrap() = Some(cx.waker().clone());
 
         // Start the background timer on first poll
@@ -132,6 +132,11 @@ impl Future for Delay {
                     w.wake(); // "Hey executor, I'm ready — poll me again!"
                 }
             });
+        }
+
+        // Double-check completion after storing waker (handles race condition)
+        if *self.completed.lock().unwrap() {
+            return Poll::Ready(());
         }
 
         Poll::Pending // Not done yet


### PR DESCRIPTION
Fixes #85.

### Description
This PR fixes a race condition in the `Delay` future example where the wake signal could be lost, leaving the future hanging indefinitely.

**The Root Cause:**
As pointed out in the issue, if the executor calls `poll` with a *new* Waker, the `poll` method overwrites `waker_stored`. However, there is a window where the background thread might finish its sleep and execute `w.wake()` using the *old* Waker while the main thread is inside `poll` (after the first check of `completed`). If this happens, `poll` would return `Poll::Pending`, but the background thread has already terminated. The executor would wait for the new Waker to be called, which will never happen.

**The Fix:**
Added a double-check of the `completed` flag at the very end of the `poll` method, right before returning `Poll::Pending`. If the background thread finishes and updates `completed` to `true` while the `poll` method is executing, this final check catches it and returns `Poll::Ready(())`, preventing the deadlock.