### PR TITLE
fix(ch02): enhance async diagram — add Reactor and OS layers (fixes #49)

### DIFF
--- a/async-book/src/ch02-the-future-trait.md
+++ b/async-book/src/ch02-the-future-trait.md
@@ -30,22 +30,34 @@ That's it. A `Future` is anything that can be *polled* — asked "are you done y
 ```mermaid
 sequenceDiagram
     participant E as Executor
-    participant F as Future
-    participant R as Resource (I/O)
+    participant F as Future (Task)
+    participant OS as Operating System<br/>(e.g., epoll/kqueue)
+    participant R as Reactor (Runtime)
 
-    E->>F: poll(cx)
-    F->>R: Check: is data ready?
-    R-->>F: Not yet
-    F->>R: Register waker from cx
-    F-->>E: Poll::Pending
+    E->>F: Calls poll(cx)
+    Note right of F: Future attempts operation
+    F->>OS: Syscall (e.g., read TCP socket)
+    OS-->>F: Returns Error: Not Ready
+    
+    F->>R: Registers: (Waker)
+    F-->>E: Returns Poll::Pending
+    Note left of E: Task is moved out<br/>of run queue
 
-    Note over R: ... time passes, data arrives ...
+    E->>E: (Executor runs other tasks OR sleeps)
+    R->>OS: epoll_wait() / Polls OS for events
 
-    R->>E: waker.wake() — "I'm ready!"
-    E->>F: poll(cx) — try again
-    F->>R: Check: is data ready?
-    R-->>F: Yes! Here's the data
-    F-->>E: Poll::Ready(data)
+    Note right of OS: (Sometime Later) New data arrives
+    OS-->>R: Wakes Reactor: data is NOW READY
+    
+    R->>R: Reactor finds Waker
+    R->>E: Calls Waker::wake()
+    Note right of E: Task is pushed back<br/>to Executor's run queue
+
+    E->>F: Calls poll(cx) again
+    Note right of F: Future attempts operation again
+    F->>OS: Syscall (e.g., read TCP socket)
+    OS-->>F: Success: Returns Data Buffer
+    F-->>E: Returns Poll::Ready(Data)
 ```
 
 Let's break down each piece:


### PR DESCRIPTION
## Description
Improves the Mermaid diagram in Chapter 2 (The Future Trait) to better illustrate the interaction between Executor, Future, Reactor, and Operating System.
## Changes
- Replaced simplified diagram that lumps Reactor + OS + Resource together
- Added explicit Reactor and OS (epoll/kqueue) participants
- Shows the flow: poll → syscall → register waker → executor waits → OS notifies reactor → reactor wakes executor → poll again
This more accurately represents how async Rust actually works under the hood, making it clearer for learners who want to understand the full async stack.
## Before/After
Before: Executor → Future → Resource (too simplified)
After: Executor → Future → OS → Reactor (shows full async pipeline)
## Related Issue
Fixes #49
---
Commit Message
fix: improve async diagram clarity in ch02 (adds Reactor + OS)
- Separates Reactor and Operating System from Resource
- Shows explicit syscall flow: poll → syscall → register waker
- Adds OS polling (epoll/kqueue) and Reactor wake flow
- Better reflects how async Rust works under the hood
Fixes #49