### PR TITLE
fix(ffi): fixed create simple logger implementation, removed duplicated word in comment

### DIFF
--- a/c-cpp-book/src/ch14-unsafe-rust-and-ffi.md
+++ b/c-cpp-book/src/ch14-unsafe-rust-and-ffi.md
@@ -207,8 +207,8 @@ pub extern "C" fn create_simple_logger(file_name: *const std::os::raw::c_char, o
         return 1;
     }
     let file_name = file_name.unwrap();
-    // Assume some defaults; we'll pass them in in real life
-    let new_logger = SimpleLogger::new(file_name, false, LogLevel::CRITICAL);
+    // Assume some defaults; we'll pass them in real life
+    let new_logger = SimpleLogger::new(file_name, true, LogLevel::CRITICAL);
     // Check that we were able to construct the logger
     if new_logger.is_err() {
         return 1;


### PR DESCRIPTION
## Description
This PR resolves an initialization failure in the FFI tutorial example where `create_simple_logger` fails to create a logger if the target log file does not already exist. 

Currently, the `create_simple_logger` function hardcodes the `overwrite` parameter to `false` when calling `SimpleLogger::new`. Under the hood, the `create_or_open_log_file` helper routes `false` to `OpenOptions::new().write(true).append(true).open(log_file)`. Because it lacks the `.create(true)` flag, this call returns an error on a fresh run when the file is absent. As a result, the FFI wrapper catches the error, returns `1`, and leaves the C-caller without a valid logger instance. From my perspective, current behavior is somewhat counterintuitive for an educational example, as it forces the reader to manually create the file before running the code or figure out why it silently fails.

## Proposed Changes
To ensure the example works out-of-the-box:
- **Default Flag Adjustment:** Changed the hardcoded `overwrite` argument from `false` to `true` inside `create_simple_logger`. This ensures `File::create` is called, guaranteeing the file is generated if it doesn't exist.
- **Comment Typo Fix:** Removed a duplicated preposition (`in in real life` -> `in real life`) in the adjacent comment block.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have tested the changes locally.