### PR TITLE
fix(async-book): delete duplicate backslashes

### DIFF
--- a/async-book/src/ch16-summary-and-reference-card.md
+++ b/async-book/src/ch16-summary-and-reference-card.md
@@ -21,7 +21,7 @@
 | Run two futures concurrently | `tokio::join!(a, b)` |
 | Race two futures | `tokio::select! { ... }` |
 | Spawn a background task | `tokio::spawn(async { ... })` |
-| Run blocking code in async | `tokio::task::spawn_blocking(\\|\\| { ... })` |
+| Run blocking code in async | `tokio::task::spawn_blocking(\|\| { ... })` |
 | Limit concurrency | `Semaphore::new(N)` |
 | Collect many task results | `JoinSet` |
 | Share state across tasks | `Arc<Mutex<T>>` or channels |


### PR DESCRIPTION
In file  `async-book/src/ch16-summary-and-reference-card.md`, there were two duplicate backslashes.
The line:
```
| Run blocking code in async | `tokio::task::spawn_blocking(\\|\\| { ... })` |
```

Now deleted. And it looks fine for local preview.
