### PR TITLE
Fix escaping of special characters with backslashes

### DIFF
--- a/rust-patterns-book/src/ch07-closures-and-higher-order-functions.md
+++ b/rust-patterns-book/src/ch07-closures-and-higher-order-functions.md
@@ -118,13 +118,13 @@ assert_eq!(result, vec![4, 16, 36, 64, 100]);
 
 | Combinator | What It Does | Example |
 |-----------|-------------|---------|
-| `.map(f)` | Transform each element | `.map(|x| x * 2)` |
-| `.filter(p)` | Keep elements where predicate is true | `.filter(|x| x > &5)` |
-| `.filter_map(f)` | Map + filter in one step (returns `Option`) | `.filter_map(|x| x.parse().ok())` |
-| `.flat_map(f)` | Map then flatten nested iterators | `.flat_map(|s| s.chars())` |
-| `.fold(init, f)` | Reduce to single value (like `Aggregate` in C#) | `.fold(0, |acc, x| acc + x)` |
-| `.any(p)` / `.all(p)` | Short-circuit boolean check | `.any(|x| x > 100)` |
-| `.enumerate()` | Add index | `.enumerate().map(|(i, x)| ...)` |
+| `.map(f)` | Transform each element | `.map(\|x\| x * 2)` |
+| `.filter(p)` | Keep elements where predicate is true | `.filter(\|x\| x > &5)` |
+| `.filter_map(f)` | Map + filter in one step (returns `Option`) | `.filter_map(\|x\| x.parse().ok())` |
+| `.flat_map(f)` | Map then flatten nested iterators | `.flat_map(\|s\| s.chars())` |
+| `.fold(init, f)` | Reduce to single value (like `Aggregate` in C#) | `.fold(0, \|acc, x\| acc + x)` |
+| `.any(p)` / `.all(p)` | Short-circuit boolean check | `.any(\|x\| x > 100)` |
+| `.enumerate()` | Add index | `.enumerate().map(\|(i, x)\| ...)` |
 | `.zip(other)` | Pair with another iterator | `.zip(labels.iter())` |
 | `.take(n)` / `.skip(n)` | First/skip N elements | `.take(10)` |
 | `.chain(other)` | Concatenate two iterators | `.chain(extra.iter())` |


### PR DESCRIPTION
### What does this PR do?
Fixes a broken Markdown table rendering in the "Common combinators cheat sheet" section.

### Why is this necessary?
The pipe characters (`|`) used in the Rust closures (e.g., `|x| x * 2`) within inline code blocks were being misinterpreted by the mdBook Markdown parser as table column separators. This caused the table columns to misalign and the rendering to break for rows containing closures.

### How was it fixed?
Escaped the pipe characters inside the inline code blocks to prevent the parser from treating them as structural table delimiters, ensuring the cheat sheet renders correctly.