### PR TITLE
fix(csharp-book): correct HighFrequencyTrader ownership example in markdown

### DIFF
--- a/csharp-book/src/ch01-introduction-and-motivation.md
+++ b/csharp-book/src/ch01-introduction-and-motivation.md
@@ -438,9 +438,12 @@ struct HighFrequencyTrader {
 
 impl HighFrequencyTrader {
     fn process_market_data(&mut self, tick: MarketTick) {
+        // Extract Copy field before moving `tick` into analysis
+        let price = tick.price;
+
         // Zero allocations, predictable performance
         let analysis = MarketAnalysis::from(tick);
-        self.trades.push(Trade::new(analysis.signal(), tick.price));
+        self.trades.push(Trade::new(analysis.signal(), price));
         
         // No GC pauses, consistent sub-microsecond latency
         // Performance guaranteed by type system


### PR DESCRIPTION
In `csharp-book/src/ch01-introduction-and-motivation.md`, the Rust `HighFrequencyTrader` example consumed `tick` via `MarketAnalysis::from(tick)` and then tried to read `tick.price`, which is not ownership-correct Rust.

This PR applies a minimal fix by reading `price` before moving `tick`, then using that stored value when creating `Trade`.

The intent and flow of the section remain unchanged, and the snippet is now valid and clear in local preview.