### PR TITLE
docs: fix incorrect max length in take_while example

### DIFF
--- a/rust-patterns-book/src/ch08-functional-vs-imperative-when-elegance-wins.md
+++ b/rust-patterns-book/src/ch08-functional-vs-imperative-when-elegance-wins.md
@@ -351,7 +351,7 @@ let samples: Vec<f64> = std::iter::from_fn(|| Some(random()))
 ```
 
 But `take_while` *excludes* the element that fails the predicate, producing anywhere from
-zero to nine elements instead of the guaranteed-at-least-one the imperative version provides. You can work around it with `scan` or `chain`, but the imperative version
+zero to ten elements instead of the guaranteed-at-least-one the imperative version provides. You can work around it with `scan` or `chain`, but the imperative version
 is clearer.
 
 **When scoped mutability genuinely wins:**


### PR DESCRIPTION
### Description
This PR corrects a minor inaccuracy in the "Scoped mutability" sidebar regarding the maximum number of elements produced by the iterator chain example.

### Why?
The text currently claims that the iterator chain `take(10).take_while(...)` produces "anywhere from zero to nine elements". 

However, if the predicate `random::<u8>() % 3 != 0` evaluates to `true` for all 10 consecutive elements provided by `take(10)`, the resulting collection will contain exactly 10 elements. Thus, the actual range is 0 to 10, not 0 to 9.

The core argument of the paragraph remains perfectly valid: the iterator version can yield 0 elements (failing the "guaranteed-at-least-one" trait of the imperative version). This PR just fixes the understated upper bound.

### Changes Made
Updated the text from "zero to nine elements" to "zero to ten elements" to accurately reflect the iterator's potential output.