### PR TITLE
docs(async-book): remove unnecessary Unpin bound from compute_stats

### DIFF
--- a/async-book/src/ch11-streams-and-asynciterator.md
+++ b/async-book/src/ch11-streams-and-asynciterator.md
@@ -208,7 +208,7 @@ impl Stats {
     }
 }
 
-async fn compute_stats<S: futures::Stream<Item = f64> + Unpin>(stream: S) -> Stats {
+async fn compute_stats<S: futures::Stream<Item = f64>>(stream: S) -> Stats {
     stream
         .fold(
             Stats { count: 0, min: f64::INFINITY, max: f64::NEG_INFINITY, sum: 0.0 },


### PR DESCRIPTION
StreamExt::fold takes `self` by value (Self: Sized) and the resulting Fold future pin-projects to the inner stream internally, so the Unpin bound on the generic parameter is not required.