### PR TITLE
python-book/ch02: Fixes graph order in "Creating Your First Project" section

### DIFF
--- a/python-book/src/ch02-getting-started.md
+++ b/python-book/src/ch02-getting-started.md
@@ -107,7 +107,7 @@ source .venv/bin/activate              # No activation needed
 ```
 
 ```mermaid
-graph TD
+graph LR
     subgraph Python ["Python Project"]
         PP["pyproject.toml"] --- PS["src/"]
         PS --- PM["myproject/"]
@@ -120,6 +120,7 @@ graph TD
         RS --- RM["main.rs"]
         RC --- RTG["target/ (auto-generated)"]
     end
+    Python ~~~ Rust
     style Python fill:#ffeeba
     style Rust fill:#d4edda
 ```


### PR DESCRIPTION
A tiny fix for a figure ordering "typo".

Currently the two graphs of the section "[Creating Your First Project](https://microsoft.github.io/RustTraining/python-book/print.html#creating-your-first-project)" are in the wrong order. The "Rust Project" graph is rendered below the Python column of the text field above (and vice versa for the "Python Project" graph). 

This fix should enforce the right ordering by setting the mermaid `graph` layout to `LR` and connecting both `subgraphs` with an invisible link.

Tested with:
```bash
mdbook v0.5.3
mdbook-mermaid 0.17.0
```