### PR TITLE
fix(rust-patterns-book): make Lifetime Branding example enforce compile-time safety

### DIFF
--- a/rust-patterns-book/src/ch04-phantomdata-types-that-carry-no-data.md
+++ b/rust-patterns-book/src/ch04-phantomdata-types-that-carry-no-data.md
@@ -49,23 +49,32 @@ Use `PhantomData` to prevent mixing values from different "sessions" or "context
 use std::cell::RefCell;
 use std::marker::PhantomData;
 
-/// A handle that's valid only within a specific arena's lifetime
+/// A handle branded to a specific arena instance.
+/// Invariant over 'arena — prevents using a handle from one arena with another.
 struct ArenaHandle<'arena> {
     index: usize,
-    _brand: PhantomData<&'arena ()>,
+    _brand: PhantomData<*mut &'arena ()>,
 }
 
-struct Arena {
+/// An arena that brands each handle with its unique lifetime.
+struct Arena<'arena> {
     data: RefCell<Vec<String>>,
+    _phantom: PhantomData<&'arena ()>,
 }
 
-impl Arena {
-    fn new() -> Self {
-        Arena { data: RefCell::new(Vec::new()) }
-    }
+/// Create an arena and pass it to a closure.
+/// Each call gets a unique, opaque lifetime that can't be forged.
+fn with_arena<R>(f: impl for<'arena> FnOnce(&Arena<'arena>) -> R) -> R {
+    let arena = Arena {
+        data: RefCell::new(Vec::new()),
+        _phantom: PhantomData,
+    };
+    f(&arena)
+}
 
+impl<'arena> Arena<'arena> {
     /// Allocate a string and return a branded handle
-    fn alloc(&self, value: String) -> ArenaHandle<'_> {
+    fn alloc(&self, value: String) -> ArenaHandle<'arena> {
         let mut data = self.data.borrow_mut();
         let index = data.len();
         data.push(value);
@@ -73,21 +82,22 @@ impl Arena {
     }
 
     /// Look up by handle — only accepts handles from THIS arena
-    fn get<'a>(&'a self, handle: ArenaHandle<'a>) -> String {
+    fn get(&self, handle: &ArenaHandle<'arena>) -> String {
         let data = self.data.borrow();
         data[handle.index].clone()
     }
 }
 
 fn main() {
-    let arena1 = Arena::new();
-    let handle1 = arena1.alloc("hello".to_string());
+    with_arena(|arena1| {
+        let handle1 = arena1.alloc("hello".to_string());
+        println!("{}", arena1.get(&handle1)); // ✅
 
-    // Can't use handle1 with a different arena — lifetimes won't match
-    // let arena2 = Arena::new();
-    // arena2.get(handle1); // ❌ Lifetime mismatch
-
-    println!("{}", arena1.get(handle1)); // ✅
+        // Can't use handle1 with a different arena — compile-time error
+        // with_arena(|arena2| {
+        //     arena2.get(&handle1); // ❌ borrowed data escapes outside of closure
+        // });
+    });
 }
 ```
 


### PR DESCRIPTION
Fixes #107

The "Lifetime Branding" example in ch04 used covariant `PhantomData<&'a ()>`,
which allowed the compiler to unify lifetimes across different arena instances.
When uncommenting the cross-arena call:

```rust
let arena2 = Arena::new();
arena2.get(handle1);
```

It compiled successfully but panicked at runtime with an index out of bounds
error.
Changes
- ArenaHandle: Changed _brand from PhantomData<&'arena ()> (covariant)
to PhantomData<*mut &'arena ()> (invariant), preventing the compiler from
coercing handles between different arena lifetimes.
- Arena: Added a lifetime parameter 'arena with PhantomData<&'arena ()>
so each arena instance carries a unique lifetime brand.
- with_arena() closure: Each call creates a unique, opaque lifetime via
for<'arena>. Handles can't escape their arena's scope.
- get(): Changed to take &ArenaHandle to avoid ownership conflicts
when testing cross-arena usage.
Verification
- Normal usage compiles and runs correctly
- Cross-arena usage now produces a compile-time error:
borrowed data escapes outside of closure
(the struct ArenaHandle<'arena> is invariant over the parameter 'arena)