### PR TITLE
fix(python-book): prevent u64 overflow in cpu_work threading example

### DIFF
--- a/python-book/src/ch01-introduction-and-motivation.md
+++ b/python-book/src/ch01-introduction-and-motivation.md
@@ -265,7 +265,7 @@ fn cpu_work(n: u64) -> u64 {
 fn main() {
     let start = std::time::Instant::now();
     let handles: Vec<_> = (0..4)
-        .map(|_| thread::spawn(|| cpu_work(10_000_000)))
+        .map(|_| thread::spawn(|| cpu_work(3_000_000)))
         .collect();
 
     let results: Vec<u64> = handles.into_iter()


### PR DESCRIPTION
Fixes #111

The `cpu_work` function sums squares from 0 to 9,999,999, which
overflows `u64` (~3.33e20 exceeds u64::MAX ~1.84e19). In debug mode
this panics with "attempt to add with overflow".

Changed `10_000_000` to `3_000_000` so the result (~9e18) fits in u64
with margin. This keeps the focus on the teaching point (Rust's true
parallelism, no GIL) without introducing u128 or overflow handling
concepts that would distract the reader.