### PR TITLE
docs: object safety → dyn compatibility, and fix the rule list in rust-patterns-book ch02

### DIFF
--- a/async-book/src/ch10-async-traits.md
+++ b/async-book/src/ch10-async-traits.md
@@ -140,7 +140,7 @@ async fn spawn_lookup<S: SendDataStore + 'static>(store: Arc<S>) {
 
 // ⚠️ Note: trait_variant does NOT enable dyn dispatch.
 // The generated trait still uses `impl Future`, so `dyn SendDataStore`
-// is not object-safe. For dyn dispatch, you still need manual boxing
+// is not dyn compatible. For dyn dispatch, you still need manual boxing
 // (see the Box::pin approach above) or the `async-trait` crate.
 ```
 

--- a/rust-patterns-book/src/ch02-traits-in-depth.md
+++ b/rust-patterns-book/src/ch02-traits-in-depth.md
@@ -272,7 +272,11 @@ Not every trait can be used as `dyn Trait`. A trait is **dyn compatible** only i
 2. **No generic type parameters** on methods
 3. **No use of `Self`** anywhere in a method signature except in the type of the
    receiver — this covers parameters as well as return types
-4. **No associated functions** (methods must have `&self`, `&mut self`, or `self`)
+4. **Every associated function must be dispatchable or opted out.** A dispatchable
+   method needs a receiver of type `&self`, `&mut self`, `self: Box<Self>`,
+   `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where `P` is one of
+   those. Anything else — including a bare `fn create() -> Self` — must carry
+   `where Self: Sized` to be excluded from the vtable
 
 ```rust
 // ✅ Dyn compatible — can be used as dyn Drawable
@@ -314,11 +318,28 @@ trait Converter {
     //        ^^^ The vtable can't contain infinite monomorphizations
 }
 
-// ❌ NOT dyn compatible — associated function (no self)
+// ❌ NOT dyn compatible — associated function with no receiver
 trait Factory {
     fn create() -> Self;
-    // No &self — how would you call this through a trait object?
+    // "...because associated function `create` has no `self` parameter"
 }
+
+// ✅ Same function, opted out of the vtable — the trait is dyn compatible again
+trait FactoryFixed {
+    fn describe(&self) -> String;      // dispatchable
+    fn create() -> Self where Self: Sized; // excluded from the vtable
+}
+
+// ⚠️ `self` by value is NOT a dispatchable receiver — it implies
+//    `where Self: Sized`. The trait stays dyn compatible, but the method
+//    simply isn't in the vtable and can't be called through `dyn Trait`:
+trait Consume {
+    fn describe(&self) -> String; // in the vtable
+    fn consume(self) -> String;   // implicitly `where Self: Sized`
+}
+// let t: &dyn Consume = &token;  // ✅ the trait object is fine
+// boxed.consume();               // ❌ error[E0161]: cannot move a value
+//                                //    of type `dyn Consume`
 ```
 
 **Workarounds**:

--- a/rust-patterns-book/src/ch02-traits-in-depth.md
+++ b/rust-patterns-book/src/ch02-traits-in-depth.md
@@ -282,6 +282,8 @@ Not every trait can be used as `dyn Trait`. A trait is **dyn compatible** only i
 6. **No associated constants**, and **no associated types with generics** (GATs).
    Plain associated types are fine, but must be pinned down at the use site:
    `dyn Iterator<Item = u32>`, never a bare `dyn Iterator`
+7. **No opaque return types** on dispatchable methods — neither `async fn` (which
+   hides a `Future` type) nor return-position `impl Trait`
 
 ```rust
 // ✅ Dyn compatible — can be used as dyn Drawable
@@ -370,6 +372,22 @@ trait LendingIterator {
 // This is the same LendingIterator from the GATs section above: the price of
 // a lending iterator is that `dyn LendingIterator` can never exist.
 
+// ❌ NOT dyn compatible — opaque return type (RPITIT)
+trait Container {
+    fn items(&self) -> impl Iterator<Item = u32>;
+    //                 ^^^^ "...references an `impl Trait` type in its return type"
+}
+
+// ❌ NOT dyn compatible — `async fn` is the same problem with sugar on top
+trait DataStore {
+    async fn get(&self, key: &str) -> Option<String>;
+    // "...because method `get` is `async`"
+}
+// Workaround for both: erase the type yourself and return a concrete boxed
+// trait object — `Box<dyn Iterator<Item = u32> + '_>` and
+// `Pin<Box<dyn Future<Output = Option<String>> + '_>>` are ordinary types,
+// so they get ordinary vtable slots.
+
 // ⚠️ `self` by value is NOT a dispatchable receiver — it implies
 //    `where Self: Sized`. The trait stays dyn compatible, but the method
 //    simply isn't in the vtable and can't be called through `dyn Trait`:
@@ -404,6 +422,18 @@ trait MyTrait {
 > `where Self: Sized` on an individual method is the sanctioned opt-out shown
 > above. When in doubt, try `let _: Box<dyn YourTrait>;` and let the compiler
 > tell you.
+
+> **Why `AsyncFn` isn't dyn compatible**: the Reference lists `AsyncFn`,
+> `AsyncFnMut` and `AsyncFnOnce` as a separate rule, but the compiler shows it's
+> really a corollary of the GAT rule above — it blames
+> `AsyncFnMut::CallRefFuture<'a>`, a generic associated type in the std
+> definition. Plain `Fn`/`FnMut`/`FnOnce` have no such member and are dyn
+> compatible, which is why `Box<dyn Fn(u32) -> u32>` works fine.
+
+> **See also**: the RPITIT section below uses `-> impl Trait` in a trait
+> definition — convenient, but it costs the trait its dyn compatibility.
+> [Async Book — Ch 10](../async-book/ch10-async-traits.html) covers the
+> `async fn` half and the `Pin<Box<dyn Future>>` workaround in depth.
 
 ### Trait Objects Under the Hood — vtables and Fat Pointers
 
@@ -610,6 +640,11 @@ impl Container for FixedFields {
 
 > **Before Rust 1.75**, you had to use `Box<dyn Iterator>` or an associated
 > type to achieve this in traits. RPITIT removes the allocation.
+>
+> **But it costs dyn compatibility**: `-> impl Trait` is an opaque return type,
+> so `dyn Container` is rejected (see [Dyn Compatibility](#dyn-compatibility-formerly-object-safety),
+> rule 7). If you need the trait object, keep returning
+> `Box<dyn Iterator<Item = &str> + '_>` and pay the allocation.
 
 #### `impl Trait` vs `dyn Trait` — Decision Guide
 

--- a/rust-patterns-book/src/ch02-traits-in-depth.md
+++ b/rust-patterns-book/src/ch02-traits-in-depth.md
@@ -2,7 +2,7 @@
 
 > **What you'll learn:**
 > - Associated types vs generic parameters — and when to use each
-> - GATs, blanket impls, marker traits, and trait object safety rules
+> - GATs, blanket impls, marker traits, and dyn compatibility rules
 > - How vtables and fat pointers work under the hood
 > - Extension traits, enum dispatch, and typed command patterns
 
@@ -264,9 +264,9 @@ fn record_measurement<S: Calibrated>(sensor: &S) {
 
 This connects directly to the **type-state pattern** in Chapter 3.
 
-### Trait Object Safety Rules
+### Dyn Compatibility (formerly "Object Safety")
 
-Not every trait can be used as `dyn Trait`. A trait is **object-safe** only if:
+Not every trait can be used as `dyn Trait`. A trait is **dyn compatible** only if:
 
 1. **No `Self: Sized` bound** on the trait itself
 2. **No generic type parameters** on methods
@@ -274,7 +274,7 @@ Not every trait can be used as `dyn Trait`. A trait is **object-safe** only if:
 4. **No associated functions** (methods must have `&self`, `&mut self`, or `self`)
 
 ```rust
-// ✅ Object-safe — can be used as dyn Drawable
+// ✅ Dyn compatible — can be used as dyn Drawable
 trait Drawable {
     fn draw(&self);
     fn bounding_box(&self) -> (f64, f64, f64, f64);
@@ -282,20 +282,20 @@ trait Drawable {
 
 let shapes: Vec<Box<dyn Drawable>> = vec![/* ... */]; // ✅ Works
 
-// ❌ NOT object-safe — uses Self in return position
+// ❌ NOT dyn compatible — uses Self in return position
 trait Cloneable {
     fn clone_self(&self) -> Self;
     //                       ^^^^ Can't know the concrete size at runtime
 }
 // let items: Vec<Box<dyn Cloneable>> = ...; // ❌ Compile error
 
-// ❌ NOT object-safe — generic method
+// ❌ NOT dyn compatible — generic method
 trait Converter {
     fn convert<T>(&self) -> T;
     //        ^^^ The vtable can't contain infinite monomorphizations
 }
 
-// ❌ NOT object-safe — associated function (no self)
+// ❌ NOT dyn compatible — associated function (no self)
 trait Factory {
     fn create() -> Self;
     // No &self — how would you call this through a trait object?
@@ -546,7 +546,7 @@ Do you know the concrete type at compile time?
 | Performance | Best — inlinable | One indirection per call |
 | Heterogeneous collections | ❌ | ✅ |
 | Binary size per type | One copy each | Shared code |
-| Trait must be object-safe? | No | Yes |
+| Trait must be dyn compatible? | No | Yes |
 | Works in trait definitions | ✅ (Rust 1.75+) | Always |
 
 ***
@@ -917,7 +917,7 @@ Is the set of types closed (known at compile time)?
 | Cache-friendly | No (pointer chasing) | Yes (contiguous) |
 | Open to new types | ✅ (anyone can impl) | ❌ (closed set) |
 | Code size | Shared | One copy per variant |
-| Trait must be object-safe | Yes | No |
+| Trait must be dyn compatible | Yes | No |
 | Adding a variant | No code changes | Update enum + match arms |
 
 ### When to Use Enum Dispatch

--- a/rust-patterns-book/src/ch02-traits-in-depth.md
+++ b/rust-patterns-book/src/ch02-traits-in-depth.md
@@ -358,9 +358,12 @@ trait MyTrait {
 // when the concrete type is known.
 ```
 
-> **Rule of thumb**: If you plan to use `dyn Trait`, keep methods simple —
-> no generics, no `Self` in return types, no `Sized` bounds. When in doubt,
-> try `let _: Box<dyn YourTrait>;` and let the compiler tell you.
+> **Rule of thumb**: If you plan to use `dyn Trait`, keep methods simple — no
+> generic type parameters, no `Self` outside the receiver, and no `Sized`
+> **supertrait**. Note the asymmetry: `trait Widget: Sized` is fatal, while
+> `where Self: Sized` on an individual method is the sanctioned opt-out shown
+> above. When in doubt, try `let _: Box<dyn YourTrait>;` and let the compiler
+> tell you.
 
 ### Trait Objects Under the Hood — vtables and Fat Pointers
 

--- a/rust-patterns-book/src/ch02-traits-in-depth.md
+++ b/rust-patterns-book/src/ch02-traits-in-depth.md
@@ -266,6 +266,13 @@ This connects directly to the **type-state pattern** in Chapter 3.
 
 ### Dyn Compatibility (formerly "Object Safety")
 
+> **A note on the name**: this was called *object safety* until Rust 1.84. The
+> term was misleading on both halves — Rust has no "objects" in the OOP sense, and
+> nothing here is about memory safety. The question is simply "can this trait be
+> used as `dyn Trait`?". The compiler now says `the trait 'X' is not dyn
+> compatible` (still error `E0038`), but most existing articles, crate docs and
+> Stack Overflow answers you'll find still say "object safe" — same concept.
+
 Not every trait can be used as `dyn Trait`. A trait is **dyn compatible** only if:
 
 1. **`Sized` must not be a supertrait** — i.e. the trait must not require `Self: Sized`

--- a/rust-patterns-book/src/ch02-traits-in-depth.md
+++ b/rust-patterns-book/src/ch02-traits-in-depth.md
@@ -279,6 +279,9 @@ Not every trait can be used as `dyn Trait`. A trait is **dyn compatible** only i
    those. Anything else — including a bare `fn create() -> Self` — must carry
    `where Self: Sized` to be excluded from the vtable
 5. **All supertraits must themselves be dyn compatible** — the property is inherited
+6. **No associated constants**, and **no associated types with generics** (GATs).
+   Plain associated types are fine, but must be pinned down at the use site:
+   `dyn Iterator<Item = u32>`, never a bare `dyn Iterator`
 
 ```rust
 // ✅ Dyn compatible — can be used as dyn Drawable
@@ -347,6 +350,25 @@ trait Derived: Base {
     fn show(&self);
 }
 // let d: &dyn Derived = ...; // ❌ Compile error, blamed on `Base::make`
+
+// ❌ NOT dyn compatible — an associated const has no vtable representation
+trait Sensor {
+    const MAX: f64;
+    //    ^^^ "...because it contains associated const `MAX`"
+    fn read(&self) -> f64;
+}
+// Workaround: make it a method — `fn max_reading(&self) -> f64`. Note there is
+// NO `where Self: Sized` escape hatch here; `const MAX: f64 where Self: Sized;`
+// isn't even accepted syntax on stable (generic const items are unstable).
+
+// ❌ NOT dyn compatible — a GAT is a family of types, not one type
+trait LendingIterator {
+    type Item<'a> where Self: 'a;
+    //   ^^^^ "...because it contains generic associated type `Item`"
+    fn next(&mut self) -> Option<Self::Item<'_>>;
+}
+// This is the same LendingIterator from the GATs section above: the price of
+// a lending iterator is that `dyn LendingIterator` can never exist.
 
 // ⚠️ `self` by value is NOT a dispatchable receiver — it implies
 //    `where Self: Sized`. The trait stays dyn compatible, but the method

--- a/rust-patterns-book/src/ch02-traits-in-depth.md
+++ b/rust-patterns-book/src/ch02-traits-in-depth.md
@@ -270,7 +270,8 @@ Not every trait can be used as `dyn Trait`. A trait is **dyn compatible** only i
 
 1. **No `Self: Sized` bound** on the trait itself
 2. **No generic type parameters** on methods
-3. **No use of `Self` in return position** (except via indirection like `Box<Self>`)
+3. **No use of `Self`** anywhere in a method signature except in the type of the
+   receiver — this covers parameters as well as return types
 4. **No associated functions** (methods must have `&self`, `&mut self`, or `self`)
 
 ```rust
@@ -282,12 +283,30 @@ trait Drawable {
 
 let shapes: Vec<Box<dyn Drawable>> = vec![/* ... */]; // ✅ Works
 
-// ❌ NOT dyn compatible — uses Self in return position
+// ❌ NOT dyn compatible — mentions Self outside the receiver
 trait Cloneable {
     fn clone_self(&self) -> Self;
-    //                       ^^^^ Can't know the concrete size at runtime
+    //                      ^^^^ "...because method `clone_self` references
+    //                            the `Self` type in its return type"
 }
 // let items: Vec<Box<dyn Cloneable>> = ...; // ❌ Compile error
+
+// ❌ Same rule, argument position — this is why PartialEq isn't dyn compatible
+trait Comparable {
+    fn equals(&self, other: &Self) -> bool;
+    //                       ^^^^ "...references the `Self` type in this parameter"
+}
+
+// ⚠️ Wrapping in Box does NOT help — Box<Self> still names Self
+trait Spawner {
+    fn spawn(&self) -> Box<Self>; // ❌ Still not dyn compatible
+}
+
+// ✅ Return Box<dyn Trait> instead — that's a concrete type, not Self.
+// This is the standard "clone through a trait object" idiom:
+trait CloneableDyn {
+    fn clone_box(&self) -> Box<dyn CloneableDyn>;
+}
 
 // ❌ NOT dyn compatible — generic method
 trait Converter {

--- a/rust-patterns-book/src/ch02-traits-in-depth.md
+++ b/rust-patterns-book/src/ch02-traits-in-depth.md
@@ -269,7 +269,8 @@ This connects directly to the **type-state pattern** in Chapter 3.
 Not every trait can be used as `dyn Trait`. A trait is **dyn compatible** only if:
 
 1. **No `Self: Sized` bound** on the trait itself
-2. **No generic type parameters** on methods
+2. **No generic type parameters** on methods — lifetime parameters *are* allowed,
+   since they're erased before codegen and need no extra vtable slot
 3. **No use of `Self`** anywhere in a method signature except in the type of the
    receiver — this covers parameters as well as return types
 4. **Every associated function must be dispatchable or opted out.** A dispatchable
@@ -316,6 +317,12 @@ trait CloneableDyn {
 trait Converter {
     fn convert<T>(&self) -> T;
     //        ^^^ The vtable can't contain infinite monomorphizations
+}
+
+// ✅ Dyn compatible — a generic LIFETIME is fine, only type params are barred
+trait Tokenizer {
+    fn first_token<'a>(&self, input: &'a str) -> &'a str;
+    //            ^^^^ One vtable slot is enough: lifetimes are erased
 }
 
 // ❌ NOT dyn compatible — associated function with no receiver

--- a/rust-patterns-book/src/ch02-traits-in-depth.md
+++ b/rust-patterns-book/src/ch02-traits-in-depth.md
@@ -268,7 +268,7 @@ This connects directly to the **type-state pattern** in Chapter 3.
 
 Not every trait can be used as `dyn Trait`. A trait is **dyn compatible** only if:
 
-1. **No `Self: Sized` bound** on the trait itself
+1. **`Sized` must not be a supertrait** — i.e. the trait must not require `Self: Sized`
 2. **No generic type parameters** on methods — lifetime parameters *are* allowed,
    since they're erased before codegen and need no extra vtable slot
 3. **No use of `Self`** anywhere in a method signature except in the type of the
@@ -278,6 +278,7 @@ Not every trait can be used as `dyn Trait`. A trait is **dyn compatible** only i
    `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` where `P` is one of
    those. Anything else — including a bare `fn create() -> Self` — must carry
    `where Self: Sized` to be excluded from the vtable
+5. **All supertraits must themselves be dyn compatible** — the property is inherited
 
 ```rust
 // ✅ Dyn compatible — can be used as dyn Drawable
@@ -336,6 +337,16 @@ trait FactoryFixed {
     fn describe(&self) -> String;      // dispatchable
     fn create() -> Self where Self: Sized; // excluded from the vtable
 }
+
+// ❌ NOT dyn compatible — inherited from a supertrait that isn't.
+//    Nothing is wrong with Derived itself; the compiler points at Base::make.
+trait Base {
+    fn make() -> Self;
+}
+trait Derived: Base {
+    fn show(&self);
+}
+// let d: &dyn Derived = ...; // ❌ Compile error, blamed on `Base::make`
 
 // ⚠️ `self` by value is NOT a dispatchable receiver — it implies
 //    `where Self: Sized`. The trait stays dyn compatible, but the method


### PR DESCRIPTION
 Some background, since this is my first contribution here. I've been programming for a long time, though in other stacks - Rust is the new one for me. I want to say first that this material is excellent: ch02 goes deeper than most trait material I've found.

While reading, I asked an AI assistant to sanity-check a few sections against the current Reference. The intent was just to confirm the object safety → dyn compatibility rename. It came back with more than that, so rather than take it at face value I put every rule through rustc 1.95.0 in a scratch project - a compiling example and a failing example per rule. Two of the chapter's four rules turned out to be genuinely wrong, and the failing cases produce the error messages quoted throughout.

I kept the commits atomic - drop whichever ones don't hold up and the rest still stand on their own.

---

Rust renamed *object safety* to **dyn compatibility** in 1.84. The rename missed the release notes, but it's settled everywhere that matters - [the Reference](https://doc.rust-lang.org/reference/items/traits.html#dyn-compatibility), rustdoc, and the compiler itself, which now says `the trait 'X' is not dyn compatible` for `E0038`.

While updating the terminology in `rust-patterns-book` ch02, I checked the chapter's rule list against the Reference and found it's not only outdated wording: **the list has 4 rules where the Reference has 6, and two of the 4 are factually wrong.**

Every rule touched here was verified against **rustc 1.95.0** in a scratch project before being written - one example per rule, each with the compiling case and the failing case. The compiler messages quoted in the commits and in the prose are literal output, not paraphrase.

## Commits

Each commit is one self-contained fix, so any of them can be dropped without disturbing the others.

| # | Commit | What |
|---|--------|------|
| 1 | `docs: rename "object safety" to "dyn compatibility"` | **Pure terminology.** No technical content touched. Also fixes an internal inconsistency in `async-book` ch10, where line 80 already said "not dyn-compatible" while line 143 still said "not object-safe". |
| 2 | `fix: correct the Self-in-method rule` | The rule said *"No use of `Self` in return position (except via indirection like `Box<Self>`)"*. Both halves are wrong - see below. |
| 3 | `fix: correct the associated-function rule and list valid receivers` | The rule said *"No associated functions (methods must have `&self`, `&mut self`, or `self`)"*. Both halves are wrong - see below. |
| 4 | `fix: fix contradictory Sized advice in the rule of thumb` | The tip says "no `Sized` bounds" three lines after the Workarounds block recommends exactly `where Self: Sized`. |
| 5 | `docs: note that lifetime parameters are allowed` | Rule 2 was correct but incomplete: type parameters are barred, lifetime parameters are not. |
| 6 | `docs: add the supertrait rules` | Missing rule: all supertraits must themselves be dyn compatible. |
| 7 | `docs: add associated const and GAT restrictions` | Missing rules: no associated constants, no generic associated types. |
| 8 | `docs: add the opaque return type restriction` | Missing rule: no `async fn`, no return-position `impl Trait`. |
| 9 | `docs: note the rename` | Short historical note so readers recognise "object safe" in older material. |

## The two factual errors

**Rule 3 - `Self` is not only about return position.** The Reference says a dispatchable method must "not use `Self` except in the type of the receiver", which covers arguments too. The old wording could not explain why `PartialEq` (`fn eq(&self, other: &Self)`) isn't dyn compatible. rustc emits two distinct messages here:

```
...because method `clone_self` references the `Self` type in its return type
...because method `equals` references the `Self` type in this parameter
```

**Rule 3 - `Box<Self>` is not an escape hatch.** `Box<Self>` is a valid *receiver* (`self: Box<Self>`), not a valid return type; `fn spawn(&self) -> Box<Self>` is still rejected. The actual "clone through a trait object" idiom is `-> Box<dyn Trait>`, which names a concrete type rather than `Self`.

**Rule 4 - associated functions are allowed.** They just need `where Self: Sized` to be opted out of the vtable. rustc suggests this fix itself in the `E0038` note.

**Rule 4 - `self` by value is not a dispatchable receiver.** It *implies* `where Self: Sized`. A trait with a `self`-by-value method is still dyn compatible - the method is simply absent from the vtable. Calling it through the trait object fails with `E0161: cannot move a value of type dyn Consume`, not `E0038`. The rule now lists the real receiver set: `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, `self: Pin<P>` - all six verified dispatching through a trait object.

## Two things worth flagging for review

**The GAT and RPITIT rules land close to home.** The chapter teaches GATs (`LendingIterator`) and RPITIT (`fn items(&self) -> impl Iterator<..>`, presented as a strict improvement over `Box<dyn Iterator>`) without mentioning that both cost the trait its dyn compatibility. Commits 7 and 8 add cross-references in both directions.

**Associated constants have no `where Self: Sized` opt-out.** Readers will try it by analogy with methods. It isn't accepted syntax on stable - `E0658`, generic const items are experimental ([rust#113521](https://github.com/rust-lang/rust/issues/113521)). The workaround is to turn the constant into a method, which the text now says.

## Verification

- `cargo xtask build` - 7/7 books build clean.
- Rendered HTML checked: the rule list renders as a 7-item `<ol>`, the section anchor resolves, and the new cross-reference to `async-book` ch10 points at a file that exists.
- No `SUMMARY.md` or internal link referenced the old `#trait-object-safety-rules` anchor, so renaming the heading breaks nothing in-repo.
