### PR TITLE
Add monthly Dependabot updates for Cargo and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
## Summary

- Add monthly Dependabot updates for the Cargo workspace and GitHub Actions.
- Group minor and patch updates while leaving major updates separate.

PR #121 covers weekly GitHub Actions updates only. This PR also covers the verified Cargo workspace and applies the requested monthly schedule and grouping policy to both ecosystems.

## Validation

- Validated the configuration against the SchemaStore Dependabot v2 schema.
- Confirmed that the root Cargo workspace covers `xtask` and its `ctrlc` dependency.
- Confirmed the action references in `.github/workflows`.
- Confirmed that Docker references use build arguments or a local image, so Docker is excluded.
- Confirmed that the diff contains only `.github/dependabot.yml`.
